### PR TITLE
Small fix to make DuelTileEntity inheritable

### DIFF
--- a/src/main/java/de/cas_ual_ty/ydm/duel/block/DuelTileEntity.java
+++ b/src/main/java/de/cas_ual_ty/ydm/duel/block/DuelTileEntity.java
@@ -19,7 +19,7 @@ public class DuelTileEntity extends BlockEntity implements MenuProvider
 {
     public DuelManager duelManager;
     
-    public DuelTileEntity(BlockEntityType<DuelTileEntity> tileEntityType, BlockPos pos, BlockState state)
+    public DuelTileEntity(BlockEntityType<? extends DuelTileEntity> tileEntityType, BlockPos pos, BlockState state)
     {
         super(tileEntityType, pos, state);
         duelManager = null;


### PR DESCRIPTION
This modification just makes a type more general and shouldn't alter the mod in any way. This is however useful to make it possible to create subclasses of DuelTileEntity, because we can then pass a variable of type BlockEntityType<SubclassOfDuelTileEntity> when calling DuelTileEntity's constructor in the subclass's constructor. I'm currently working on a mod relying on YDM and I need to inherit DuelTileEntity at some point so this solved my problem.